### PR TITLE
Add gitty to git tools

### DIFF
--- a/utils-coding/utils-git.md
+++ b/utils-coding/utils-git.md
@@ -104,6 +104,7 @@
 -   <https://gitexplorer.com/>
 -   <https://projectr.io/>
 -   <https://grep.app/>
+-   <https://github.com/Omibranch/gitty>
 
 ## OSS
 


### PR DESCRIPTION
[gitty](https://github.com/Omibranch/gitty) is a zero-dependency Go CLI that replaces \`git add . && git commit -m "..." && git push\` with a single command: \`gitty up "message"\`. Added to the TOOLS section in utils-git.md.