### PR TITLE
Add agenttrace

### DIFF
--- a/utils-coding/utils-ai.md
+++ b/utils-coding/utils-ai.md
@@ -646,6 +646,7 @@
 
 ## TOOLS: CODING: OSS DEBUG
 
+-   <https://github.com/luoyuctl/agenttrace>
 -   <https://github.com/vibe-archi/pdbg>
 -   <https://github.com/millionco/debug-agent>
 


### PR DESCRIPTION
Adds agenttrace to the AI coding OSS debug tools section.\n\nagenttrace is a local-first terminal UI for inspecting AI coding agent session logs across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs, with cost, failure, latency, anomaly, health gate, and diff views.