### PR TITLE
Add TinyTools to Web tools section

### DIFF
--- a/utils-all/utils-tools.md
+++ b/utils-all/utils-tools.md
@@ -107,6 +107,7 @@
 -   <https://measurethat.net/Tools>
 -   <https://oscarleo.com/google-trends>
 -   <https://metatags.io/font-generator>
+-   <https://tinytools-smoky.vercel.app/>
 
 ## OSS: ALL
 


### PR DESCRIPTION
Adds **TinyTools** (https://tinytools-smoky.vercel.app/) to `utils-all/utils-tools.md` under the **## Web** section.

TinyTools is a free, open-source collection of single-purpose web utilities — all browser-based, no signup. Includes:

- Domain name generator
- OG image generator
- AI background remover (runs locally)
- Favicon generator
- Color palette generator
- SEO meta tag generator
- AI cost calculator
- AI content disclosure generator (EU AI Act compliant)
- AI robots.txt generator

Fits alongside neighbours like `it-tools.tech`, `transform.tools`, and `onlineminitools.com` in the Web section.
