### PR TITLE
Add Commitment Issues to Various section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@
 -   [GraphQL](utils-coding/utils-graphql.md)
 -   [Database](utils-coding/utils-database.md)
 -   [More](utils-coding/)
+- [Commitment Issues](https://commitmentissues.dev) - Free open-source web app that scans any GitHub repo for abandonment signals and issues a satirical death certificate with cause of death, last commit date, and contributor analysis. Useful before depending on a project. ([source](https://github.com/dotsystemsdevs/commitmentissues))
 
 ## Blockchain
 


### PR DESCRIPTION
Adding [Commitment Issues](https://commitmentissues.dev) to the Various section.

## What it does
Free open-source web app that scans any GitHub repository and issues a satirical "death certificate" with cause of death, last commit date, contributor patterns, and a severity score. Useful before depending on a project or to clean up dead bookmarks.

## Why it fits
- **Utility for developers** — diagnose abandonment signals before adopting a dependency
- **MIT open source** — full code on GitHub
- **No signup, no ads** — paste a URL, get an answer
- **Includes a graveyard** of famous casualties (jQuery UI, async, bluebird, etc.)

Source: https://github.com/dotsystemsdevs/commitmentissues

Thanks for maintaining this list! 🦥