### PR TITLE
Add Jsonic (JSON to TypeScript) to TypeScript TOOLS

### DIFF
--- a/utils-coding/utils-typescript.md
+++ b/utils-coding/utils-typescript.md
@@ -142,6 +142,7 @@
 
 -   <https://tsdocs.dev>
 -   <http://json2ts.com>
+-   <https://jsonic.io/json-to-ts>
 -   <https://tsdiagram.com>
 -   <https://tsconfig.guide>
 -   <https://ts-ast-viewer.com>


### PR DESCRIPTION
Adds [Jsonic](https://jsonic.io/json-to-ts) to the TypeScript **TOOLS** section, alongside json2ts.com. It's a free, in-browser (no-signup) tool that generates TypeScript interfaces from JSON — fits the same slot as the existing json2ts entry.