### PR TITLE
Add Mini-Tools.uk AI Prompt Helper

### DIFF
--- a/utils-coding/utils-ai.md
+++ b/utils-coding/utils-ai.md
@@ -436,6 +436,7 @@
 
 ## TOOLS: PROMPT EXTRA
 
+-   <https://mini-tools.uk/promo-prompt.html>
 -   <https://markdown.new/>
 -   <https://summarize.sh/>
 


### PR DESCRIPTION
Adds Mini-Tools.uk AI Prompt Helper to the prompt tools section.\n\nIt is a small browser-based helper for turning rough instructions into clearer prompts for coding, writing, research, image prompts, and automation workflows.\n\nLink: https://mini-tools.uk/promo-prompt.html\n\nRefs #33