### PR TITLE
Add usage to TOOLS: CODING: OSS CLAUDE

### DIFF
--- a/utils-coding/utils-ai.md
+++ b/utils-coding/utils-ai.md
@@ -790,6 +790,7 @@
 -   <https://github.com/anthropics/financial-services-plugins>
 -   <https://github.com/anthropics/claude-code-security-review>
 -   <https://github.com/EveryInc/compounding-engineering-plugin>
+-   <https://github.com/aqua5230/usage>
 
 ## TOOLS: CODING: OSS OPTIMIZE PROMPT RULES / SKILLS
 


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage) — an open-source (AGPL-3.0) macOS menu bar app that pins Claude Code and Codex quota (5-hour / weekly) to the screen, with burn-rate predictions and offline HTML usage reports. It never calls the Anthropic/OpenAI API; all numbers come from local files, so monitoring adds zero token overhead. Installable via `brew install --cask aqua5230/usage/usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)