### PR TITLE
Add Markstream to TypeScript AI libraries

### DIFF
--- a/utils-coding/utils-typescript.md
+++ b/utils-coding/utils-typescript.md
@@ -350,6 +350,7 @@
 
 -   <https://github.com/run-llama/LlamaIndexTS>
 -   <https://github.com/mastra-ai/mastra>
+-   <https://github.com/Simon-He95/markstream-vue>
 
 ## LIB: FUNCTIONNAL PROGRAMMING
 


### PR DESCRIPTION
## Summary

Add Markstream to **TypeScript → LIB: AI**.

Markstream is an actively maintained, MIT-licensed TypeScript project that provides streaming Markdown renderers for AI chat interfaces across Vue, React, Svelte, and Angular.

The placement and proposed change were first documented in #39, following the contribution guidelines. I also verified that the repository did not already contain Markstream.

Disclosure: I maintain Markstream. Thank you for reviewing the addition!

Closes #39
