### PR TITLE
Add nutilz.com to Web tools section

### DIFF
--- a/utils-all/utils-tools.md
+++ b/utils-all/utils-tools.md
@@ -111,6 +111,7 @@
 -   <https://oscarleo.com/google-trends>
 -   <https://metatags.io/font-generator>
 -   <https://tinytools-smoky.vercel.app/>
+-   <https://nutilz.com/>
 
 ## OSS: ALL
 


### PR DESCRIPTION
Adds nutilz.com, a free collection of browser-based calculators, converters, generators, and developer/text/image utilities (no signup required), to the Web tools section — alongside similar multi-tool sites already listed like it-tools.tech, onlineminitools.com, and TinyTools.