### PR TITLE
Replace dead gas oracle links (gasnow.org, ethgasstation.info)

### DIFF
--- a/utils-chain/utils-chain-eth.md
+++ b/utils-chain/utils-chain-eth.md
@@ -83,11 +83,11 @@
 -   <https://ethplorer.io>
 -   <https://chainlist.wtf>
 -   <https://chainlist.org>
--   <https://www.gasnow.org>
+-   <https://openchainbench.com/benchmarks/gas-estimation>
 -   <https://www.monobase.xyz>
 -   <https://ethplorer.io/top>
 -   <https://www.etherchain.org>
--   <https://ethgasstation.info>
+-   <https://gas.blocknative.com>
 -   <https://etherscan.io/gastracker>
 
 ## ETH NEWS


### PR DESCRIPTION
## Summary

Two entries in the Ethereum utils section point to services that no longer work:

- `https://www.gasnow.org` — API discontinued 2021, domain now serves unrelated content
- `https://ethgasstation.info` — HTTP 403 (Cloudflare parked page) since around 2023

## Change

Replaces the two dead entries with two live alternatives commonly used today:

- [OpenChainBench gas benchmark](https://openchainbench.com/benchmarks/gas-estimation): independent cross-provider gas oracle accuracy comparison, CC BY 4.0
- [Blocknative Gas Platform](https://gas.blocknative.com): professional gas price API

Kept the surrounding entries intact.

## Disclosure

I maintain OpenChainBench. Happy to drop the OpenChainBench reference and keep only Blocknative + Etherscan Gas Tracker if you prefer.