### PR TITLE
Add Poszo Next.js Security Headers Starter

### DIFF
--- a/utils-coding/utils-security.md
+++ b/utils-coding/utils-security.md
@@ -175,6 +175,7 @@
 -   <https://github.com/edoardottt/awesome-hacker-search-engines>
 -   <https://github.com/hkithub-official/no-plaintext-passwords>
 -   <https://github.com/decalage2/awesome-security-hardening>
+-   <https://github.com/poszothebuilder/nextjs-security-headers-starter>
 -   <https://github.com/Authenticator-Extension/Authenticator>
 -   <https://github.com/intigriti/misconfig-mapper>
 -   <https://github.com/productdevbook/port-killer>


### PR DESCRIPTION
## Summary

- add the Poszo Next.js Security Headers Starter to `TOOLS: OSS: DEFENSIVE`
- use the list’s existing direct-link format

The resource is free, public, dependency-free, MIT-licensed, and has a tagged v1.0.0 release. It provides a Next.js response-header configuration, report-only CSP example, production verifier, rollback guidance, and documented limitations.

I maintain this resource for Poszo; this is a disclosed self-submission.

Closes #43.

## Checks

- `git diff --check`
- source repository returns HTTPS 200
- one documentation line changed; no repository scripts or dependencies executed
