### PR TITLE
Add DevProjex to coding tools

### DIFF
--- a/utils-coding/utils-ai.md
+++ b/utils-coding/utils-ai.md
@@ -673,6 +673,7 @@
 -   <https://github.com/aaif-goose/goose>
 -   <https://github.com/appdotbuild/agent>
 -   <https://github.com/yamadashy/repomix>
+-   <https://github.com/Avazbek22/DevProjex>
 -   <https://github.com/e2b-dev/fragments>
 -   <https://github.com/Nutlope/aicommits>
 -   <https://github.com/cursor/agent-trace>


### PR DESCRIPTION
Adds the DevProjex repository next to Repomix in `TOOLS: CODING: OSS`, using the existing direct-link format. References #45.