### PR TITLE
Add All Tools Verse to Web tools

### DIFF
--- a/utils-all/utils-tools.md
+++ b/utils-all/utils-tools.md
@@ -113,6 +113,7 @@
 -   <https://tinytools-smoky.vercel.app/>
 -   <https://mini-tools.uk/>
 -   <https://nutilz.com/>
+-   <https://alltoolsverse.com/>
 -   <https://jsonic.io>
 
 ## OSS: ALL


### PR DESCRIPTION
Adds All Tools Verse to `utils-all/utils-tools.md` under the `Web` section.

All Tools Verse is a collection of 1,000+ free browser-based tools for development, files, images, text, data, conversions, and everyday tasks. No signup is required for normal use.

It matches existing entries such as IT Tools, TinyTools, and nutilz.com.

Disclosure: I am the maker.

References #47.