### PR TITLE
docs: add WeekLife

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@
 
 -   [Microfrontend](utils-coding/utils-microfrontend.md)
 -   [Monorepo](utils-coding/utils-monorepo.md)
+- [WeekLife](https://letmethink.cc/app/weeklife/) - A lightweight life check-in tool for reclaiming everyday life beyond work.
 
 ## Mobile Development
 


### PR DESCRIPTION
Hi! I'd like to suggest adding WeekLife to this list.

- [WeekLife](https://letmethink.cc/app/weeklife/) — A lightweight life check-in tool designed to help people reclaim their weekdays.

I reviewed the list and believe this project fit the selected section. Happy to adjust the wording or placement to match the maintainers' preference.

Thanks for maintaining this resource.