### PR TITLE
docs(api): add apistatuscheck.com under HEALTHCHECK

### DIFF
--- a/utils-coding/utils-api.md
+++ b/utils-coding/utils-api.md
@@ -343,6 +343,7 @@
 
 ## HEALTHCHECK
 
+-   <https://apistatuscheck.com/>
 -   <https://github.com/brotandgames/ciao>
 -   <https://github.com/openstatusHQ/openstatus>
 


### PR DESCRIPTION
Closes #53 (filed first, per CONTRIBUTING step 1).

One line in `utils-coding/utils-api.md`, bare-URL house style, no other changes:

```
## HEALTHCHECK

+-   <https://apistatuscheck.com/>
-   <https://github.com/brotandgames/ciao>
-   <https://github.com/openstatusHQ/openstatus>
```

**Why it belongs next to those two rather than duplicating them.** ciao and openstatus both answer *"is my own endpoint up?"*. This answers the inverse — *"the third-party API I depend on just started 503ing; is it them or is it me?"* — across 285 public APIs and developer platforms in 29 categories. Same section, the other direction.

**Verifiable without an account**, which is the only reason to take the numbers above seriously:

```
curl -s https://apistatuscheck.com/api/status | jq "{count, categories: (.categories | length)}"
# {"count": 285, "categories": 29}   (run 2026-08-15)
```

There is also a read-only MCP endpoint at `https://apistatuscheck.com/api/mcp` (streamable HTTP, no auth) if that is of interest for the AI list — not added here, since this PR is deliberately one line.

**Disclosure:** my own project, submitted under my own account. Status data is free and needs no signup. Happy to move it to `AGGREGATION`, add a short description, or close this if you would rather `HEALTHCHECK` stay strictly self-hosted monitors.