### PR TITLE
Add Nutilz — free web developer tools (JSON formatter, Regex tester)

### DIFF
--- a/utils-coding/utils-regex.md
+++ b/utils-coding/utils-regex.md
@@ -16,6 +16,7 @@
 -   <https://www.regextester.com/>
 -   <https://www.textfixer.com/tools/>
 -   <https://pythonium.net/regex>
+-   <https://nutilz.com/regex-tester>
 
 ## Oss
 

--- a/utils-coding/utils-web-dev.md
+++ b/utils-coding/utils-web-dev.md
@@ -166,6 +166,7 @@
 
 -   <https://dsgn.link>
 -   <https://free-for.dev>
+-   <https://nutilz.com>
 
 ## TOOLS: CODE
 
@@ -182,6 +183,7 @@
 -   <https://json-diff.com>
 -   <https://jsonvisio.com>
 -   <https://jsoncrack.com>
+-   <https://nutilz.com/json-formatter>
 -   <https://waterfaller.dev>
 -   <https://www.mydevice.io>
 -   <https://www.jsv9000.app>


### PR DESCRIPTION
Hi @pegaltier!

This PR adds [Nutilz](https://nutilz.com) to the curated lists under `utils-coding/utils-web-dev.md` and `utils-coding/utils-regex.md`.

Nutilz offers 23 free browser-based developer utilities including JSON formatter/diff, Regex tester, JWT decoder, cURL-to-code converter, and CSS/SVG tools. Everything runs locally in-browser with no sign-up or tracking required.

Thank you for maintaining this awesome list!