### PR TITLE
Add YAML Preflight to online developer tools

### DIFF
--- a/utils-all/utils-tools.md
+++ b/utils-all/utils-tools.md
@@ -124,6 +124,7 @@
 -   <https://it-tools.tech/>
 -   <https://transform.tools/>
 -   <https://codebeautify.org/>
+-   <https://susscr.github.io/yaml-preflight/>
 
 ## ONLINE TOOLS: VIDEOS
 


### PR DESCRIPTION
Adds https://susscr.github.io/yaml-preflight/ to ONLINE TOOLS: DEV.

YAML Preflight is a free, browser-only checker for YAML syntax, duplicate mapping keys, and common GitHub Actions permissions mistakes. It requires no signup, sends no document to a backend, and is maintained by aevumere. Source: https://github.com/susscr/yaml-preflight

Closes #61