### PR TITLE
docs: add AI Weekly resource

### DIFF
--- a/utils-coding/utils-ai.md
+++ b/utils-coding/utils-ai.md
@@ -298,6 +298,7 @@
 -   <https://9elements.com/blog/ai-glossary>
 -   <https://www.agentrecipes.com/>
 -   <https://learnprompting.org/>
+-   <https://aiweekly.co/>
 -   <https://www.superhuman.ai>
 -   <https://www.therundown.ai>
 -   <https://www.fast.ai>


### PR DESCRIPTION
## Summary

Adds AI Weekly's canonical URL to the existing AI resource links in `utils-coding/utils-ai.md`.

Closes #63.

## Verification

- canonical URL returned successfully
- `git diff --check` passed

## Disclosure

I am the founder of AI Weekly. I used an AI assistant to help prepare this narrowly scoped contribution and reviewed the submitted wording and diff.
